### PR TITLE
Dump edges and nodes to flatgeobuffer files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,12 +1,12 @@
 ---
-Language:        Cpp
+Language: Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlinesLeft: false
-AlignOperands:   true
+AlignOperands: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: true
@@ -20,45 +20,45 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: false
 BinPackArguments: true
 BinPackParameters: false
-BraceWrapping:   
-  AfterClass:      false
+BraceWrapping:
+  AfterClass: false
   AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
-ColumnLimit:     102
-CommentPragmas:  '^ IWYU pragma:'
+ColumnLimit: 75
+CommentPragmas: "^ IWYU pragma:"
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-DisableFormat:   false
+DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+ForEachMacros: [foreach, Q_FOREACH, BOOST_FOREACH]
 IncludeCategories:
-  - Regex:           '^<'
-    Priority:        3
-  - Regex:           '^"(valhalla)/(baldr|bindings|loki|meili|midgard|mjolnir|odin|proto|sif|skadi|thor|tyr")'
-    Priority:        2
-  - Regex:           '.*'
-    Priority:        1
+  - Regex: "^<"
+    Priority: 3
+  - Regex: '^"(valhalla)/(baldr|bindings|loki|meili|midgard|mjolnir|odin|proto|sif|skadi|thor|tyr")'
+    Priority: 2
+  - Regex: ".*"
+    Priority: 1
 IndentCaseLabels: true
-IndentWidth:     2
+IndentWidth: 2
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: true
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
+MacroBlockBegin: ""
+MacroBlockEnd: ""
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBlockIndentWidth: 2
@@ -71,21 +71,21 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
-ReflowComments:  true
-SortIncludes:    true
+ReflowComments: true
+SortIncludes: true
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
-TabWidth:        8
-UseTab:          Never
+Standard: Cpp11
+TabWidth: 2
+UseTab: Never
 BreakStringLiterals: false
-...
+---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,16 @@ set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ language version to use (default is 
 pkg_check_modules(libprime_server IMPORTED_TARGET libprime_server>=0.6.3)
 pkg_check_modules(libvalhalla REQUIRED IMPORTED_TARGET libvalhalla>=3.4.0)
 
+# GDAL 
+  find_package(GDAL)
+  if (GDAL_FOUND)
+    set(GDAL_TARGET GDAL::GDAL)
+  endif()
+
 find_package(Boost CONFIG)
 target_compile_definitions(PkgConfig::libvalhalla INTERFACE ENABLE_DATA_TOOLS)
 
-set(programs valhalla_remove_predicted_traffic valhalla_decode_buckets)
+set(programs valhalla_remove_predicted_traffic valhalla_decode_buckets valhalla_get_tile_ids valhalla_export_tiles)
 set(lib_sources traffic.cc)
 list(TRANSFORM lib_sources PREPEND ${CMAKE_SOURCE_DIR}/src/)
 
@@ -45,10 +51,11 @@ target_include_directories(${lib} PUBLIC
 
 foreach(program_ ${programs})
   add_executable(${program_} ${CMAKE_SOURCE_DIR}/src/${program_}.cc)
-  target_link_libraries(${program_} PRIVATE PkgConfig::libvalhalla Boost::boost ${lib})
+  target_link_libraries(${program_} PRIVATE PkgConfig::libvalhalla Boost::boost GDAL::GDAL ${lib})
   target_include_directories(${program_} 
   PRIVATE 
     PkgConfig::libvalhalla 
+    GDAL::GDAL
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party/cxxopts/include)
 endforeach()
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Usage:
 
 Outputs one row per 5-minute bucket, each containing the index and the decoded speed separated by a comma.
 
+## `valhalla_get_tile_ids`
+
+```sh
+
+```
+
+## `valhalla_export_tiles`
+
+```sh
+
+```
+
 ### Building from source
 
 You need valhalla installed on your system. CMake will try to locate the lib and the headers using PkgConfig.

--- a/src/valhalla_decode_buckets.cc
+++ b/src/valhalla_decode_buckets.cc
@@ -4,7 +4,8 @@
 
 namespace {
 void print_bucket_speeds(const std::string& encoded) {
-  std::array<int16_t, 200> coefs = valhalla::baldr::decode_compressed_speeds(encoded);
+  std::array<int16_t, 200> coefs =
+      valhalla::baldr::decode_compressed_speeds(encoded);
   for (size_t i = 0; i < valhalla::baldr::kBucketsPerWeek; ++i) {
     auto speed = valhalla::baldr::decompress_speed_bucket(&coefs[0], i);
     std::cout << i << "," << speed << "\n";
@@ -40,8 +41,10 @@ int main(int argc, char** argv) {
   if (vm.count("ENCODED") == 1) {
     encoded = vm["ENCODED"].as<std::vector<std::string>>();
   } else {
-    std::cout << "Single encoded speeds string required\n";
+    std::cerr << "Single encoded speeds string required\n";
+    return EXIT_FAILURE;
   }
 
   print_bucket_speeds(encoded[0]);
+  return EXIT_SUCCESS;
 }

--- a/src/valhalla_export_tiles.cc
+++ b/src/valhalla_export_tiles.cc
@@ -1,0 +1,313 @@
+
+#include <cxxopts.hpp>
+#include <valhalla/baldr/graphid.h>
+#include <valhalla/baldr/graphreader.h>
+#include <valhalla/mjolnir/graphtilebuilder.h>
+#include <valhalla/proto/api.pb.h>
+#include <valhalla/proto/options.pb.h>
+#include <valhalla/proto_conversions.h>
+#include <valhalla/sif/costfactory.h>
+#include <valhalla/sif/dynamiccost.h>
+
+#include "argparse_utils.h"
+#include <gdal_priv.h>
+#include <ogrsf_frmts.h>
+
+namespace {
+
+OGRLineString* ConvertToOGRLineString(const std::vector<PointLL>& points) {
+  OGRLineString* line = new OGRLineString();
+  for (const auto& pt : points) {
+    line->addPoint(pt.lng(), pt.lat()); // Note: OGR uses (X=lon, Y=lat)
+  }
+  return line;
+}
+
+valhalla::sif::cost_ptr_t create_costing(const std::string& costing_str) {
+  valhalla::Options options;
+  valhalla::Costing::Type costing;
+  if (valhalla::Costing_Enum_Parse(costing_str, &costing)) {
+    options.set_costing_type(costing);
+  } else {
+    options.set_costing_type(valhalla::Costing::none_);
+  }
+  auto& co = (*options.mutable_costings())[costing];
+  co.set_type(costing);
+  return valhalla::sif::CostFactory{}.Create(options);
+}
+enum class FeatureType : uint8_t { kEdges = 0, kNodes = 1 };
+
+/**
+ * Exports features that match the passed tileid to the specified
+ * directory.
+ */
+void export_tile(valhalla::baldr::GraphReader& reader,
+                 const valhalla::baldr::GraphId tile_id,
+                 const std::string& output_dir,
+                 const bool edges,
+                 const bool nodes,
+                 valhalla::Api& request,
+                 valhalla::sif::cost_ptr_t costing,
+                 GDALDriver* gdal_driver,
+                 char** dataset_options) {
+  // get the file path
+  auto suffix =
+      valhalla::baldr::GraphTile::FileSuffix(tile_id.Tile_Base(), ".fgb");
+  auto disk_location =
+      output_dir + filesystem::path::preferred_separator + suffix;
+
+  // make sure all the subdirectories exist
+  auto dir = filesystem::path(disk_location);
+  dir.replace_filename("");
+  filesystem::create_directories(dir);
+  LOG_INFO("Writing to disk at " + disk_location);
+  GDALDataset* dataset = gdal_driver->Create(disk_location.c_str(), 0, 0,
+                                             0, GDT_Unknown, nullptr);
+  if (!dataset) {
+    printf("Failed to create output file.\n");
+    return;
+  }
+
+  OGRSpatialReference spatialRef;
+  spatialRef.SetWellKnownGeogCS("WGS84");
+
+  OGRLayer* edges_layer;
+  OGRLayer* nodes_layer;
+  if (edges)
+    edges_layer = dataset->CreateLayer("edges", &spatialRef, wkbLineString,
+                                       dataset_options);
+
+  if (nodes)
+    nodes_layer = dataset->CreateLayer("nodes", &spatialRef, wkbPoint,
+                                       dataset_options);
+
+  if ((edges && !edges_layer) || (nodes && !nodes_layer)) {
+    LOG_ERROR("Failed to create layer.");
+    GDALClose(dataset);
+    return;
+  }
+
+  // now go through the tile and convert the features
+  if (!reader.DoesTileExist(tile_id)) {
+    LOG_ERROR("Tile " + std::to_string(tile_id) +
+              " does not exist. Skipping...");
+    return;
+  }
+  // Trim reader if over-committed
+  if (reader.OverCommitted()) {
+    reader.Trim();
+  }
+
+  auto tile = reader.GetGraphTile(tile_id);
+
+  for (size_t idx = 0; idx < tile->header()->directededgecount(); ++idx) {
+    auto de = tile->directededge(idx);
+    // if (!de->is_shortcut())
+    //   continue;
+    auto ei = tile->edgeinfo(de);
+
+    auto shape = ei.shape();
+    OGRLineString* line = ConvertToOGRLineString(shape);
+    OGRFeature* feature =
+        OGRFeature::CreateFeature(edges_layer->GetLayerDefn());
+    feature->SetGeometry(line);
+    if (edges_layer->CreateFeature(feature) != OGRERR_NONE) {
+      LOG_ERROR("Failed to create feature");
+    }
+
+    OGRFeature::DestroyFeature(feature);
+  }
+
+  GDALClose(dataset);
+};
+
+void work(boost::property_tree::ptree& config,
+          const std::string& output_dir,
+          bool edges,
+          bool nodes,
+          valhalla::Api& request,
+          valhalla::sif::cost_ptr_t costing,
+          std::queue<valhalla::baldr::GraphId>& tile_queue,
+          std::mutex& lock) {
+
+  valhalla::baldr::GraphReader reader(config.get_child("mjolnir"));
+  valhalla::baldr::GraphId tile_id;
+  const char* driver_name = "FlatGeobuf";
+  GDALDriver* driver =
+      GetGDALDriverManager()->GetDriverByName(driver_name);
+  if (!driver) {
+    LOG_ERROR("FlatGeoBuf driver not available");
+    return;
+  }
+  // create some options
+  char** dataset_options = NULL;
+  dataset_options =
+      CSLSetNameValue(dataset_options, "SPATIAL_INDEX", "YES");
+
+  while (true) {
+    {
+      std::lock_guard l(lock);
+      if (tile_queue.empty())
+        break;
+      tile_id = tile_queue.front();
+      tile_queue.pop();
+    }
+    export_tile(reader, tile_id, output_dir, edges, nodes, request,
+                costing, driver, dataset_options);
+  }
+}
+
+/**
+ * Exports features that match the passed tileids to the specified
+ * directory
+ *
+ * @param config the config object
+ * @param output_dir the directory to which the files will be written
+ * (follows graph tile structuring within the directory)
+ * @param edges whether to export edges
+ * @param nodes whether to export nodes
+ * @param request some request options, right now only used for the costing
+ * and attribute controlling
+ * @param costing the costing to filter allowed/disallowed edges
+ * @param tile_ids which tiles to export
+ */
+int export_tiles(boost::property_tree::ptree& config,
+                 const std::string& output_dir,
+                 const bool edges,
+                 const bool nodes,
+                 valhalla::Api& request,
+                 valhalla::sif::cost_ptr_t costing,
+                 std::vector<std::string>& tile_ids) {
+
+  std::queue<valhalla::baldr::GraphId> tile_queue;
+
+  // fill up a queue
+  for (const auto& tile_id : tile_ids) {
+    tile_queue.emplace(tile_id);
+  }
+  // no need for this anymore
+  tile_ids.resize(0);
+  tile_ids.shrink_to_fit();
+
+  // multithread it
+  std::vector<std::shared_ptr<std::thread>> threads(
+      config.get<size_t>("mjolnir.concurrency"));
+  std::mutex lock;
+
+  for (size_t i = 0; i < threads.size(); ++i) {
+    threads[i] =
+        std::make_shared<std::thread>(work, std::ref(config),
+                                      std::cref(output_dir), edges, nodes,
+                                      std::ref(request), costing,
+                                      std::ref(tile_queue),
+                                      std::ref(lock));
+  }
+
+  for (const auto& thread : threads)
+    thread->join();
+
+  return EXIT_SUCCESS;
+};
+
+} // namespace
+int main(int argc, char** argv) {
+  const auto program = filesystem::path(__FILE__).stem().string();
+  boost::property_tree::ptree pt;
+  std::vector<std::string> tile_ids;
+  std::string output_dir;
+  std::vector<std::string> ftypes = {"edges"};
+  valhalla::Api request;
+  std::string costing_str;
+  bool edges = false;
+  bool nodes = false;
+
+  try {
+    cxxopts::Options
+        options(program,
+                "exports edges and/or nodes into FlatGeoBuf files.\n");
+
+    // clang-format off
+    options.add_options()
+    ("h,help", "Print this help message.")
+    ("j,concurrency", "Number of threads to use.", cxxopts::value<unsigned int>())
+    ("c,config", "Path to the json configuration file.", cxxopts::value<std::string>())
+    ("i,inline-config", "Inline json config.",cxxopts::value<std::string>())
+    ("o,costing", "Costing to use", cxxopts::value<std::string>())
+    ("a,attributes", "Attributes to include/exclude", cxxopts::value<std::string>())
+    ("f,feature-type", "Feature types to output (currently supports node and edges, defaults to edges only)", cxxopts::value<std::vector<std::string>>())
+    ("d,output-directory", "Directory in which output files will be written", cxxopts::value<std::string>())
+    ("TILEID", "If provided, only export features matching the passed tile IDs. Can alternatively be passed via stdin", cxxopts::value<std::vector<std::string>>());
+    // clang-format on
+
+    // options.custom_help("TILEID");
+    options.positional_help("TILEID");
+    options.parse_positional({"TILEID"});
+
+    auto result = options.parse(argc, argv);
+    if (!parse_common_args(program, options, result, pt, "mjolnir.logging",
+                           true))
+      return EXIT_SUCCESS;
+
+    // try from positional arguments
+    if (result["TILEID"].count() != 0) {
+      tile_ids = result["TILEID"].as<std::vector<std::string>>();
+    }
+
+    // read tile ids from stdin
+    if (tile_ids.size() == 0) {
+      std::string tileid;
+      while (std::getline(std::cin, tileid)) {
+        if (!tileid.empty()) {
+          tile_ids.push_back(tileid);
+        }
+      }
+    }
+
+    if (tile_ids.size() == 0) {
+      LOG_INFO("No Tile IDs passed, exporting all tiles");
+    }
+
+    if (result["output-directory"].count() > 0) {
+      output_dir = result["output-directory"].as<std::string>();
+    } else {
+      throw cxxopts::exceptions::missing_argument("output-dir");
+    }
+
+    if (result["feature-type"].count() > 0) {
+      ftypes = result["feature-type"].as<std::vector<std::string>>();
+    } else {
+      LOG_INFO("No feature-type argument detected, defaulting to edges");
+    }
+    for (const auto& ftype : ftypes) {
+      if (ftype == "edges") {
+        edges = true;
+      } else if (ftype == "nodes") {
+        nodes = true;
+      } else {
+        LOG_WARN("Detected unsupported feature-type " + ftype);
+      }
+    }
+
+    costing_str = result["costing"].as<std::string>();
+
+  } catch (cxxopts::exceptions::exception& e) {
+    std::cerr << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cerr << "Unable to parse command line options because: "
+              << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  try {
+    // register gdal drivers
+    GDALAllRegister();
+
+    valhalla::sif::cost_ptr_t costing = create_costing(costing_str);
+    return export_tiles(pt, output_dir, edges, nodes, request, costing,
+                        tile_ids);
+  } catch (std::exception& e) {
+    std::cout << "Failed to export tiles: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+}

--- a/src/valhalla_export_tiles.cc
+++ b/src/valhalla_export_tiles.cc
@@ -1,5 +1,6 @@
 
 #include <cxxopts.hpp>
+#include <valhalla/baldr/attributes_controller.h>
 #include <valhalla/baldr/graphid.h>
 #include <valhalla/baldr/graphreader.h>
 #include <valhalla/mjolnir/graphtilebuilder.h>
@@ -14,6 +15,90 @@
 #include <ogrsf_frmts.h>
 
 namespace {
+
+struct AttributeFilter {
+  AttributeFilter(const std::vector<std::string>& includes,
+                  const std::vector<std::string>& excludes) {
+    for (const auto& include : includes) {
+      if (include == valhalla::baldr::kEdgeId) {
+        localidx = true;
+        continue;
+      }
+      if (include == valhalla::baldr::kEdgeRoadClass) {
+        road_class = true;
+        continue;
+      }
+      if (include == valhalla::baldr::kEdgeUse) {
+        use = true;
+        continue;
+      }
+      if (include == valhalla::baldr::kEdgeSpeed) {
+        speed = true;
+        continue;
+      }
+      if (include == valhalla::baldr::kEdgeTunnel) {
+        tunnel = true;
+        continue;
+      }
+      if (include == valhalla::baldr::kEdgeBridge) {
+        bridge = true;
+        continue;
+      }
+      if (include == valhalla::baldr::kEdgeTraversability) {
+        traversability = true;
+        continue;
+      }
+      if (include == valhalla::baldr::kEdgeSurface) {
+        surface = true;
+        continue;
+      }
+    }
+
+    for (const auto& exclude : excludes) {
+      if (exclude == valhalla::baldr::kEdgeId) {
+        localidx = false;
+        continue;
+      }
+      if (exclude == valhalla::baldr::kEdgeRoadClass) {
+        road_class = false;
+        continue;
+      }
+      if (exclude == valhalla::baldr::kEdgeUse) {
+        use = false;
+        continue;
+      }
+      if (exclude == valhalla::baldr::kEdgeSpeed) {
+        speed = false;
+        continue;
+      }
+      if (exclude == valhalla::baldr::kEdgeTunnel) {
+        tunnel = false;
+        continue;
+      }
+      if (exclude == valhalla::baldr::kEdgeBridge) {
+        bridge = false;
+        continue;
+      }
+      if (exclude == valhalla::baldr::kEdgeTraversability) {
+        traversability = false;
+        continue;
+      }
+      if (exclude == valhalla::baldr::kEdgeSurface) {
+        surface = false;
+        continue;
+      }
+    }
+  }
+
+  bool localidx{true};
+  bool road_class{true};
+  bool use{true};
+  bool speed{false};
+  bool tunnel{false};
+  bool bridge{false};
+  bool traversability{false};
+  bool surface{false};
+};
 
 OGRLineString* ConvertToOGRLineString(const std::vector<PointLL>& points) {
   OGRLineString* line = new OGRLineString();
@@ -49,7 +134,8 @@ void export_tile(valhalla::baldr::GraphReader& reader,
                  valhalla::Api& request,
                  valhalla::sif::cost_ptr_t costing,
                  GDALDriver* gdal_driver,
-                 char** dataset_options) {
+                 char** dataset_options,
+                 const AttributeFilter& filter) {
   // get the file path
   auto suffix =
       valhalla::baldr::GraphTile::FileSuffix(tile_id.Tile_Base(), ".fgb");
@@ -81,6 +167,16 @@ void export_tile(valhalla::baldr::GraphReader& reader,
     nodes_layer = dataset->CreateLayer("nodes", &spatialRef, wkbPoint,
                                        dataset_options);
 
+  // create fields
+  if (filter.localidx) {
+    OGRFieldDefn field_name("edgeid", OFTInteger);
+    edges_layer->CreateField(&field_name);
+  }
+  if (filter.road_class) {
+    OGRFieldDefn field_name("road_class", OFTString);
+    edges_layer->CreateField(&field_name);
+  }
+
   if ((edges && !edges_layer) || (nodes && !nodes_layer)) {
     LOG_ERROR("Failed to create layer.");
     GDALClose(dataset);
@@ -111,6 +207,15 @@ void export_tile(valhalla::baldr::GraphReader& reader,
     OGRFeature* feature =
         OGRFeature::CreateFeature(edges_layer->GetLayerDefn());
     feature->SetGeometry(line);
+
+    if (filter.localidx) {
+      feature->SetField("edgeid", static_cast<int>(idx));
+    }
+    if (filter.road_class) {
+      feature->SetField("road_class",
+                        valhalla::baldr::to_string(de->classification())
+                            .c_str());
+    }
     if (edges_layer->CreateFeature(feature) != OGRERR_NONE) {
       LOG_ERROR("Failed to create feature");
     }
@@ -127,6 +232,7 @@ void work(boost::property_tree::ptree& config,
           bool nodes,
           valhalla::Api& request,
           valhalla::sif::cost_ptr_t costing,
+          const AttributeFilter& filter,
           std::queue<valhalla::baldr::GraphId>& tile_queue,
           std::mutex& lock) {
 
@@ -153,7 +259,7 @@ void work(boost::property_tree::ptree& config,
       tile_queue.pop();
     }
     export_tile(reader, tile_id, output_dir, edges, nodes, request,
-                costing, driver, dataset_options);
+                costing, driver, dataset_options, filter);
   }
 }
 
@@ -169,6 +275,7 @@ void work(boost::property_tree::ptree& config,
  * @param request some request options, right now only used for the costing
  * and attribute controlling
  * @param costing the costing to filter allowed/disallowed edges
+ * @param filter which attributes to include/exclude
  * @param tile_ids which tiles to export
  */
 int export_tiles(boost::property_tree::ptree& config,
@@ -177,6 +284,7 @@ int export_tiles(boost::property_tree::ptree& config,
                  const bool nodes,
                  valhalla::Api& request,
                  valhalla::sif::cost_ptr_t costing,
+                 const AttributeFilter& filter,
                  std::vector<std::string>& tile_ids) {
 
   std::queue<valhalla::baldr::GraphId> tile_queue;
@@ -199,6 +307,7 @@ int export_tiles(boost::property_tree::ptree& config,
         std::make_shared<std::thread>(work, std::ref(config),
                                       std::cref(output_dir), edges, nodes,
                                       std::ref(request), costing,
+                                      std::cref(filter),
                                       std::ref(tile_queue),
                                       std::ref(lock));
   }
@@ -218,6 +327,8 @@ int main(int argc, char** argv) {
   std::vector<std::string> ftypes = {"edges"};
   valhalla::Api request;
   std::string costing_str;
+  std::vector<std::string> includes;
+  std::vector<std::string> excludes;
   bool edges = false;
   bool nodes = false;
 
@@ -233,13 +344,13 @@ int main(int argc, char** argv) {
     ("c,config", "Path to the json configuration file.", cxxopts::value<std::string>())
     ("i,inline-config", "Inline json config.",cxxopts::value<std::string>())
     ("o,costing", "Costing to use", cxxopts::value<std::string>())
-    ("a,attributes", "Attributes to include/exclude", cxxopts::value<std::string>())
+    ("e,exclude-attributes", "Attributes to exclude", cxxopts::value<std::vector<std::string>>())
+    ("a,include-attributes", "Attributes to include", cxxopts::value<std::vector<std::string>>())
     ("f,feature-type", "Feature types to output (currently supports node and edges, defaults to edges only)", cxxopts::value<std::vector<std::string>>())
     ("d,output-directory", "Directory in which output files will be written", cxxopts::value<std::string>())
     ("TILEID", "If provided, only export features matching the passed tile IDs. Can alternatively be passed via stdin", cxxopts::value<std::vector<std::string>>());
     // clang-format on
 
-    // options.custom_help("TILEID");
     options.positional_help("TILEID");
     options.parse_positional({"TILEID"});
 
@@ -288,6 +399,16 @@ int main(int argc, char** argv) {
       }
     }
 
+    if (result["include-attributes"].count() > 0) {
+      includes =
+          result["include-attributes"].as<std::vector<std::string>>();
+    }
+
+    if (result["exclude-attributes"].count() > 0) {
+      excludes =
+          result["exclude-attributes"].as<std::vector<std::string>>();
+    }
+
     costing_str = result["costing"].as<std::string>();
 
   } catch (cxxopts::exceptions::exception& e) {
@@ -303,9 +424,10 @@ int main(int argc, char** argv) {
     // register gdal drivers
     GDALAllRegister();
 
+    AttributeFilter filter(includes, excludes);
     valhalla::sif::cost_ptr_t costing = create_costing(costing_str);
     return export_tiles(pt, output_dir, edges, nodes, request, costing,
-                        tile_ids);
+                        filter, tile_ids);
   } catch (std::exception& e) {
     std::cout << "Failed to export tiles: " << e.what() << "\n";
     return EXIT_FAILURE;

--- a/src/valhalla_get_tile_ids.cc
+++ b/src/valhalla_get_tile_ids.cc
@@ -1,0 +1,94 @@
+#include <cxxopts.hpp>
+#include <iostream>
+#include <valhalla/baldr/graphid.h>
+#include <valhalla/baldr/tilehierarchy.h>
+#include <valhalla/midgard/aabb2.h>
+
+namespace {
+using namespace valhalla;
+
+const std::string delim = ",";
+
+midgard::AABB2<midgard::PointLL> parse_bbox_str(const std::string& s) {
+  size_t last = 0;
+  size_t next = 0;
+  size_t idx = 0;
+  std::array<double, 4> pts;
+
+  while ((next = s.find(delim, last)) != std::string::npos) {
+    std::string coord = s.substr(last, next - last);
+
+    if (idx > 3)
+      throw std::runtime_error("Too many coordinates provided for bbox");
+
+    try {
+      pts[idx] = std::stod(coord);
+    } catch (std::exception& e) {
+      throw std::runtime_error("Unable to parse bounding box");
+    }
+    last = next + 1;
+    ++idx;
+  }
+
+  // get the last one
+  std::string coord = s.substr(last);
+  pts[idx] = std::stod(coord);
+
+  if (idx != 3)
+    std::runtime_error("Invalid bbox string provided");
+
+  return midgard::AABB2<midgard::PointLL>(midgard::PointLL(pts[0], pts[1]),
+                                          midgard::PointLL(pts[2],
+                                                           pts[3]));
+}
+} // namespace
+
+int main(int argc, char** argv) {
+  const auto program = std::filesystem::path(__FILE__).stem().string();
+  midgard::AABB2<midgard::PointLL> bbox;
+
+  try {
+    cxxopts::Options options(program,
+                             "prints a list of Valhalla tile IDs that "
+                             "intersect with a given bounding box.");
+
+    // clang-format off
+    options.add_options()
+    ("h,help", "Print this help message.")
+    ("b,bounding-box",
+       "the bounding box to intersect with",
+       cxxopts::value<std::string>());
+    // clang-format on
+
+    auto result = options.parse(argc, argv);
+    options.custom_help("");
+    if (result.count("help")) {
+      std::cout << options.help() << "\n";
+      return EXIT_SUCCESS;
+    }
+    if (result.count("bounding-box")) {
+      bbox = parse_bbox_str(result["bounding-box"].as<std::string>());
+    } else {
+      throw cxxopts::exceptions::missing_argument("bounding-box");
+    }
+  }
+
+  catch (cxxopts::exceptions::exception& e) {
+    std::cerr << e.what() << std::endl;
+    return EXIT_FAILURE;
+  } catch (std::exception& e) {
+    std::cerr << "Unable to parse command line options because: "
+              << e.what() << "\n";
+    return EXIT_FAILURE;
+  }
+
+  try {
+    for (const auto& tile_id : baldr::TileHierarchy::GetGraphIds(bbox)) {
+      std::cout << tile_id << "\n";
+    }
+  } catch (std::exception& e) {
+    std::cerr << "Failed to remove predicted traffic: " << e.what()
+              << "\n";
+    return EXIT_FAILURE;
+  }
+}


### PR DESCRIPTION
Introduces blueprint and basic version of a command line tool that exports edges (and soon nodes) within a tile or tileset to flatgeobuf (vector format with a spatial index for fast rendering in the GIS of your choice).   